### PR TITLE
fix typos and add a dash

### DIFF
--- a/Basics.md
+++ b/Basics.md
@@ -9,11 +9,11 @@ Shaders are written in OpenGL Shading Language (GLSL), a C-like language with su
 When using shaders, especially when starting with them, I strongly recommend you use [Suso's Shader Reload mod](https://www.curseforge.com/minecraft/mc-mods/shader-reload).  
 While this is a mod, it's a fabric mod and won't modify any part of the game except for the shader reload. Make sure to *not* use other fabric mods that do affect shaders, such as sodium.  
 
-When working with shaders, especially as a beginner, you will often want to reload your resource pack to check whether it works. If there's an error in your code, Minecraft will output it in the game output, and unequip the resource pack.  
+When working with shaders, especially as a beginner, you will often want to reload your resource pack to check whether it works. If there's an error in your code, Minecraft will output it in the game output, and disable the resource pack.  
 This is avoided when using the shader reload mod. It allows you to only reload shaders (and not the rest of the resource pack), making it significantly faster. Additionally, when you make a mistake it simply doesn't reload the shaders and outputs the errors in chat. This makes debugging much more comfortable.
 
 ### Shader Subfolders
-The vanilla shaders are contained in the `assets` of the game, similarily to textures, models and similiar. They have a `shader` subfolder in the `minecraft` namespace. A copy of them can also be found in this [repo](https://github.com/misode/mcmeta/tree/assets/assets/minecraft/shaders).  
+The vanilla shaders are contained in the `assets` of the game, similarly to textures, models and similar. They have a `shader` subfolder in the `minecraft` namespace. A copy of them can also be found in this [repo](https://github.com/misode/mcmeta/tree/assets/assets/minecraft/shaders).  
 
 The `shader` folder contains 4 subfolders:
 

--- a/Core Shader List.md
+++ b/Core Shader List.md
@@ -32,7 +32,7 @@ The part in brackets is a summary and not a full list of everything each shader 
     - [entity_glint_direct](#entity_glint_direct) (Enchanted Trident Glint)
     - [glint](#glint) (Glass Enchant Glint)
     - [glint_direct](#glint_direct) (Standard Enchant Glint)
-    - [glint_translucent](#glint_translucent) (Glass enchanted glint in `Fabolous!`)
+    - [glint_translucent](#glint_translucent) (Glass enchanted glint in `Fabulous!`)
     - [energy_swirl](#energy_swirl) (Charged Creeper, Wither Swirl)
     - [eyes](#eyes) (Entities with glowing eyes)
     - [leash](#leash) (Leash)
@@ -40,7 +40,7 @@ The part in brackets is a summary and not a full list of everything each shader 
     - [entity_cutout_no_cull_z_offset](#entity_cutout_no_cull_z_offset) (Mob Skulls, Minecart, Shulker)
     - [entity_decal](#entity_decal) (Ender Dragon Death)
     - [entity_alpha](#entity_alpha) (Ender Dragon Death Wings)
-    - [item_entity_translucent_cull](#item_entity_translucent_cull) (XP Orbs, Fabolous translucent items, Invisible Entities)
+    - [item_entity_translucent_cull](#item_entity_translucent_cull) (XP Orbs, Fabulous translucent items, Invisible Entities)
     - [entity_smooth_cutout](#entity_smooth_cutout) (End Crystal Beams)
     - [entity_translucent_emissive](#entity_translucent_emissive) (Glowing parts of Warden texture)
     - [entity_no_outline](#entity_no_outline) (Banner)
@@ -339,7 +339,7 @@ The enchant glint in most situations. Enchanted worn armor is rendered by `armor
 ---
 
 ### glint_translucent
-The enchant glint in translucent blocks (like stained glass) in world when graphics setting is `Fabolous!`.
+The enchant glint in translucent blocks (like stained glass) in world when graphics setting is `Fabulous!`.
 
 <img src="images/rendertype_glint_translucent.png" width=200> 
 
@@ -520,7 +520,7 @@ These are shaders which affect some part of the UI. Some UI elements are rendere
 * The Mojang resource pack loading background color
 * The black bars on the sides when scoped in with a spyglass
 * Highlighting item slots
-* World and server selection menu dropshadow
+* World and server selection menu drop-shadow
 
 [Back to Top](#contents)
 
@@ -536,7 +536,7 @@ These are shaders which affect some part of the UI. Some UI elements are rendere
 ---
 
 ### text
-All parts of text, including the shadow. This encompasses all text rendered including: F3 Menu, Menu button text, Entity names, Text display entites, Item names, descriptions & amounts in the inventory and the Chat etc. It also does the explored parts of maps
+All parts of text, including the shadow. This encompasses all text rendered including: F3 Menu, Menu button text, Entity names, Text display entities, Item names, descriptions & amounts in the inventory and the Chat etc. It also does the explored parts of maps
 
 ---
 


### PR DESCRIPTION
😀 
You could ignore this and see the changes, there are only a few.
- Fabulous was spelt Fabolous a few times
- I chose to replace unequip with disable because it felt weird and triggered the spell checker
- similarily and similiar have an extra `i` which I would probably do myself
- drop shadow is two words :nodding:
- entities was spelt entites, a funny mistake which I do.