### PR TITLE
updated chat shadow position z

### DIFF
--- a/Core Shader List.md
+++ b/Core Shader List.md
@@ -845,6 +845,8 @@
   * 300: Item count in inventory
   * 400: Item count while dragging item, tooltip texts, compact potion info
   * 0 to 104: Maps (not actually text)
+  * 0.1 [1.21.1]: Chat Text Shadow
+  * 0.0 [1.21.1]: Chat Input Text Shadow
 
   Since maps share the z value with the chat display and a part of the hotbar item count, you can test for Sampler0 having a size of 128 pixels in both directions to test for the face being a map.
 


### PR DESCRIPTION
I checked in 1.21.1 for different text shadows and i just put the values here bc why not